### PR TITLE
Skip terraform_fmt in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip:
+    - terraform_fmt
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.56.0


### PR DESCRIPTION
It fails since it's not written in a way that'll work on the CI infra.